### PR TITLE
Set the schema of response 401 to GET /byon/phonebook/v1/numbers

### DIFF
--- a/sms/v1/openapi.yaml
+++ b/sms/v1/openapi.yaml
@@ -446,6 +446,13 @@ paths:
                   $ref: "#/components/schemas/PhoneProvisioningArrayResponse"
         "401":
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+            "*/*":
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "403":
           description: Forbidden
         "404":


### PR DESCRIPTION
Schema was not documented and seems to be an `ErrorResponse`.