### PR TITLE
Remove the format parameter from PUT /conversations/v3/channels/whatsapp/phone-numbers/{phone-number}/settings/logo

### DIFF
--- a/conversations/v3/whatsapp.yaml
+++ b/conversations/v3/whatsapp.yaml
@@ -627,8 +627,9 @@ paths:
   /channels/whatsapp/phone-numbers/{phone-number}/settings/logo:
     parameters:
       - $ref: '#/components/parameters/PhoneNumber'
-      - $ref: '#/components/parameters/WhatsAppProfileLogoFormat'
     get:
+      parameters:
+        - $ref: '#/components/parameters/WhatsAppProfileLogoFormat'
       operationId: getCurrentWALogo
       summary: Read the logo
       description: Returns the current logo assigned to a WhatsApp phone number profile.


### PR DESCRIPTION
Should be discussed whether `PUT` really does not use the `format` parameter.