### PR TITLE
Make all properties of the Problem object in Conversations API optional

### DIFF
--- a/conversations/v3/common.yaml
+++ b/conversations/v3/common.yaml
@@ -486,11 +486,6 @@ components:
       type: object
       additionalProperties: true
       description: The problem object follows the RFC-7807 (https://tools.ietf.org/html/rfc7807)
-      required:
-        - type
-        - title
-        - status
-        - detail
       properties:
         type:
           description: A URI reference [RFC3986] that identifies the problem type

--- a/conversations/v3/configurations.yaml
+++ b/conversations/v3/configurations.yaml
@@ -785,11 +785,6 @@ components:
       type: object
       additionalProperties: true
       description: The problem object follows the RFC-7807 (https://tools.ietf.org/html/rfc7807)
-      required:
-        - type
-        - title
-        - status
-        - detail
       properties:
         type:
           description: A URI reference [RFC3986] that identifies the problem type

--- a/conversations/v3/openapi.yaml
+++ b/conversations/v3/openapi.yaml
@@ -160,11 +160,6 @@ components:
       type: object
       additionalProperties: true
       description: The problem object follows the RFC-7807 (https://tools.ietf.org/html/rfc7807)
-      required:
-        - type
-        - title
-        - status
-        - detail
       properties:
         type:
           description: A URI reference [RFC3986] that identifies the problem type


### PR DESCRIPTION
**Should be discussed whether this is the proper fix.**

Several examples use only the `status` property. On the other hand, once, I got another problem object without the `status` property. The RFC seems to make all properties optional too.