### PR TITLE
Fix the name of the accountName property in CPaaSAccount example

### DIFF
--- a/conversations/v3/whatsapp.yaml
+++ b/conversations/v3/whatsapp.yaml
@@ -2434,7 +2434,7 @@ components:
           type: string
           description: Name of the CPaaSAccount
       example:
-        name: someaccount
+        accountName: someaccount
     WhatsAppTemplateRequest:
       type: object
       description: Request for an additional WhatsApp template


### PR DESCRIPTION
**Should be discussed whether this is the proper fix.**