### PR TITLE
Make example of serviceId in ViberChannelResponse a string

### DIFF
--- a/conversations/v3/configurations.yaml
+++ b/conversations/v3/configurations.yaml
@@ -716,7 +716,7 @@ components:
           - callbacks:write
           - callbacks:read
         id:
-          serviceId: 1234
+          serviceId: "1234"
         name: Your Company
         callback:
           callbackVersion: 2.11


### PR DESCRIPTION
Both the spec and the implementation returns a string.